### PR TITLE
fix: patch top 3 high-severity execution and parsing issues

### DIFF
--- a/dom.py
+++ b/dom.py
@@ -9,7 +9,7 @@ from Utils import SeqUtil
 out = sys.argv[1]
 query = sys.argv[2]
 dom = sys.argv[3]
-paml = sys.argv[4]
+paml = sys.argv[4].strip().lower() in {"1", "true", "yes", "y"}
 
 print("Beginning alignment")
 dom_out = f"{dom}-{out}"

--- a/helpers/commands.py
+++ b/helpers/commands.py
@@ -64,10 +64,8 @@ DOM = ["python3", "dom.py", "{out}", "{query}", "{dom}", "{phyml}"]
 
 def format_run(cmd, **kwargs):
     fmt = [str(c).format(**kwargs) for c in cmd]
-    try:
-        subprocess.run(fmt)
-    except:
-        os.system(" ".join(fmt))
+    print(" ".join(fmt))
+    subprocess.run(fmt, check=True)
 
 
 def clustal_align(infile, outfile, fmt="nexus"):
@@ -80,10 +78,10 @@ def run_prottest(infile, outfile):
 
 def run_blast(seed, thresh, dum, org, db="nr"):
     if db == "nr":
-        BLAST.append("-remote")
-        BLAST.append("-entrez_query")
-        BLAST.append('"{org}[ORGN]"')
-    format_run(BLAST, seed=seed, threshold=thresh, xml_file=dum, org=org, db=db)
+        new_blast = BLAST + ["-remote", "-entrez_query", f'"{org}[ORGN]"']
+    else:
+        new_blast = BLAST
+    format_run(new_blast, seed=seed, threshold=thresh, xml_file=dum, org=org, db=db)
 
 
 def run_prank(infile, outfile):
@@ -91,7 +89,7 @@ def run_prank(infile, outfile):
 
 
 def run_phyml(infile, model, outfile, v=None, a=None):
-    cmd = PHYML
+    cmd = list(PHYML)
     if v:
         cmd += ["-v", v]
     if a:


### PR DESCRIPTION
## TL;DR
Patch three high-severity runtime risks in command execution and CLI parsing.

## What changed
- Avoid global command mutation in `run_phyml` by copying `PHYML` before appending flags.
- Remove unsafe shell fallback (`os.system`) and enforce `subprocess.run(..., check=True)` in `format_run`.
- Parse `dom.py` phyml argument as a real boolean (`1/true/yes/y`) instead of truthy string behavior.
- Build BLAST command per call in `run_blast` (no global BLAST mutation).

## Testing
- `./venv1/bin/python -m pytest -q` -> 13 passed
- `python3 -m py_compile helpers/commands.py dom.py` -> OK

🌸 Generated with [AdaL](https://github.com/adal-cli/)