### PR TITLE
test: add missing critical-path coverage for commands and CLI bool parsing

### DIFF
--- a/dom.py
+++ b/dom.py
@@ -9,7 +9,7 @@ from Utils import SeqUtil
 out = sys.argv[1]
 query = sys.argv[2]
 dom = sys.argv[3]
-paml = sys.argv[4]
+paml = sys.argv[4].strip().lower() in {"1", "true", "yes", "y"}
 
 print("Beginning alignment")
 dom_out = f"{dom}-{out}"

--- a/dom.py
+++ b/dom.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 import Report
+from helpers.cli import parse_bool_arg
 from helpers.commands import run_bayes, run_phyml, run_prank, run_prottest
 from helpers.constants import AlignsPath, BayesPath, DataPath, MLPath, ProtPath
 from Utils import SeqUtil
@@ -9,7 +10,7 @@ from Utils import SeqUtil
 out = sys.argv[1]
 query = sys.argv[2]
 dom = sys.argv[3]
-paml = sys.argv[4].strip().lower() in {"1", "true", "yes", "y"}
+paml = parse_bool_arg(sys.argv[4])
 
 print("Beginning alignment")
 dom_out = f"{dom}-{out}"

--- a/helpers/cli.py
+++ b/helpers/cli.py
@@ -1,0 +1,6 @@
+TRUE_VALUES = {"1", "true", "yes", "y"}
+
+
+def parse_bool_arg(value: str) -> bool:
+    """Parse common CLI truthy values."""
+    return value.strip().lower() in TRUE_VALUES

--- a/helpers/commands.py
+++ b/helpers/commands.py
@@ -64,10 +64,8 @@ DOM = ["python3", "dom.py", "{out}", "{query}", "{dom}", "{phyml}"]
 
 def format_run(cmd, **kwargs):
     fmt = [str(c).format(**kwargs) for c in cmd]
-    try:
-        subprocess.run(fmt)
-    except:
-        os.system(" ".join(fmt))
+    print(" ".join(fmt))
+    subprocess.run(fmt, check=True)
 
 
 def clustal_align(infile, outfile, fmt="nexus"):
@@ -80,10 +78,10 @@ def run_prottest(infile, outfile):
 
 def run_blast(seed, thresh, dum, org, db="nr"):
     if db == "nr":
-        BLAST.append("-remote")
-        BLAST.append("-entrez_query")
-        BLAST.append('"{org}[ORGN]"')
-    format_run(BLAST, seed=seed, threshold=thresh, xml_file=dum, org=org, db=db)
+        new_blast = BLAST + ["-remote", "-entrez_query", f'"{org}[ORGN]"']
+    else:
+        new_blast = BLAST
+    format_run(new_blast, seed=seed, threshold=thresh, xml_file=dum, org=org, db=db)
 
 
 def run_prank(infile, outfile):
@@ -91,7 +89,7 @@ def run_prank(infile, outfile):
 
 
 def run_phyml(infile, model, outfile, v=None, a=None):
-    cmd = PHYML
+    cmd = list(PHYML)
     if v:
         cmd += ["-v", v]
     if a:

--- a/test/test_Commands.py
+++ b/test/test_Commands.py
@@ -1,0 +1,52 @@
+import unittest
+from unittest.mock import patch
+
+from helpers import commands
+
+
+class TestCommands(unittest.TestCase):
+    @patch("helpers.commands.subprocess.run")
+    def test_format_run_uses_check_true(self, mock_run):
+        commands.format_run(["echo", "{value}"], value="ok")
+        mock_run.assert_called_once_with(["echo", "ok"], check=True)
+
+    @patch("helpers.commands.format_run")
+    def test_run_phyml_uses_per_call_copy_without_mutating_global(self, mock_format_run):
+        original_phyml = list(commands.PHYML)
+
+        commands.run_phyml("infile", "JTT", "outfile", v="0.1")
+        commands.run_phyml("infile", "JTT", "outfile", a="0.2")
+
+        self.assertEqual(commands.PHYML, original_phyml)
+
+        first_cmd = mock_format_run.call_args_list[0].args[0]
+        second_cmd = mock_format_run.call_args_list[1].args[0]
+
+        self.assertIn("-v", first_cmd)
+        self.assertNotIn("-a", first_cmd)
+
+        self.assertIn("-a", second_cmd)
+        self.assertNotIn("-v", second_cmd)
+
+    @patch("helpers.commands.format_run")
+    def test_run_blast_builds_per_call_command_without_mutating_global(self, mock_format_run):
+        original_blast = list(commands.BLAST)
+
+        commands.run_blast("ABC123", 1e-5, "seed_org", "Homo sapiens", db="nr")
+        commands.run_blast("ABC123", 1e-5, "seed_org", "Homo sapiens", db="local_db")
+
+        self.assertEqual(commands.BLAST, original_blast)
+
+        nr_cmd = mock_format_run.call_args_list[0].args[0]
+        local_cmd = mock_format_run.call_args_list[1].args[0]
+
+        self.assertIn("-remote", nr_cmd)
+        self.assertIn("-entrez_query", nr_cmd)
+        self.assertIn('"Homo sapiens[ORGN]"', nr_cmd)
+
+        self.assertNotIn("-remote", local_cmd)
+        self.assertNotIn("-entrez_query", local_cmd)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,0 +1,17 @@
+import unittest
+
+from helpers.cli import parse_bool_arg
+
+
+class TestCli(unittest.TestCase):
+    def test_parse_bool_arg_truthy_inputs(self):
+        for value in ["1", "true", "TRUE", " yes ", "Y"]:
+            self.assertTrue(parse_bool_arg(value))
+
+    def test_parse_bool_arg_falsey_inputs(self):
+        for value in ["0", "false", "no", "n", "maybe", ""]:
+            self.assertFalse(parse_bool_arg(value))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## TL;DR
Add regression tests for previously untested critical execution paths, plus a small reusable CLI boolean parser used by `dom.py`.

## What changed
- Added `helpers/cli.py` with `parse_bool_arg`.
- Updated `dom.py` to use `parse_bool_arg`.
- Added `test/test_Commands.py` covering:
  - `format_run` uses `subprocess.run(..., check=True)`
  - `run_phyml` does not mutate global `PHYML`
  - `run_blast` does not mutate global `BLAST`
- Added `test/test_cli.py` covering truthy/falsey CLI bool inputs.

## Testing
- `./venv1/bin/python -m pytest -q` -> 18 passed

## Notes
This PR is stacked on top of #fix/high-severity-top3 to avoid duplicate commits in `develop`.

🌸 Generated with [AdaL](https://github.com/adal-cli/)