### PR TITLE
fix: patch remaining top risks and add Report tests

### DIFF
--- a/Report.py
+++ b/Report.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 from helpers.constants import AlignsPath, BayesPath, DataPath, MLPath, ProtPath, ReportsPath
 from Utils import FetchUtil, SeqUtil
@@ -173,9 +174,8 @@ def generate_report(name, quer, models, dom):
 def consense(fil):
     """Returns a newick consensus tree of the trees in fil"""
     filename = str(fil).split(".")[0]
-    with open("inputer", "w") as dum:
-        dum.write(str(fil) + "\nf\n" + filename + "_cons\ny\nf\n" + filename + ".tre")
-    os.system("./consense-mac.app < inputer")
+    consense_input = str(fil) + "\nf\n" + filename + "_cons\ny\nf\n" + filename + ".tre"
+    subprocess.run(["./consense-mac.app"], input=consense_input, text=True, check=True)
     tree = ""
     with open(filename + ".tre") as treefil:
         for i in treefil:

--- a/Utils/FetchUtil.py
+++ b/Utils/FetchUtil.py
@@ -56,15 +56,17 @@ def fetch_organism(acc):
     retu = [""]
     while i < len(filtered_records):
         if filtered_records[i] == "DEFINITION":
+            if i + 1 >= len(filtered_records):
+                return retu
             multispecies = filtered_records[i + 1].startswith("MULTISPECIES:")
             if not multispecies:
                 tab = filtered_records[i + 1].strip().split()
-                if not filtered_records[i + 2] == "ACCESSION":
+                if i + 2 < len(filtered_records) and not filtered_records[i + 2] == "ACCESSION":
                     tab += filtered_records[i + 2].strip().split()
                 for k in range(len(tab)):
                     if tab[k].startswith("[") and len(tab[k]) > 5:
                         retu = [tab[k][1:]]
-                        while k < len(tab):
+                        while k + 1 < len(tab):
                             k += 1
                             if tab[k].endswith("]."):
                                 retu[0] += " " + tab[k][0 : tab[k].index("]")]
@@ -73,7 +75,9 @@ def fetch_organism(acc):
                             else:
                                 retu[0] += " " + tab[k]
             else:
-                return [filtered_records[i + 11] + " multispecies", filtered_records[i + 12].split(";")[0]]
+                if i + 12 < len(filtered_records):
+                    return [filtered_records[i + 11] + " multispecies", filtered_records[i + 12].split(";")[0]]
+                return retu
 
         if filtered_records[i] == "ORGANISM":
             try:

--- a/Utils/SeqUtil.py
+++ b/Utils/SeqUtil.py
@@ -266,7 +266,7 @@ def splice_align(inalign, outalign):
                     pos.update({c: 1})
     # print pos
     # processing pos; eliminating key:value pairs whose values are less than half len(i)
-    for k in pos.keys():
+    for k in list(pos.keys()):
         if pos[k] < (0.5 * noseq):
             pos.pop(k)
     post = list(pos.keys())

--- a/test/test_Report.py
+++ b/test/test_Report.py
@@ -1,0 +1,122 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import Report
+from helpers.constants import AlignsPath, BayesPath, DataPath, MLPath, ProtPath, ReportsPath
+
+
+def _write_file(path_obj, content):
+    with open(str(path_obj), "w") as handle:
+        handle.write(content)
+
+
+class TestReport(unittest.TestCase):
+    def setUp(self):
+        self.original_cwd = os.getcwd()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        os.chdir(self.temp_dir.name)
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        self.temp_dir.cleanup()
+
+    @patch("Report.consense", return_value="(MLTREE);")
+    @patch("Report.FetchUtil.fetch_definition", side_effect=lambda acc: f"definition-for-{acc}")
+    @patch("Report.FetchUtil.fetch_organism", return_value=["Query organism", "Bacteria"])
+    def test_generate_report_prefers_con_file_and_writes_outputs(
+        self, _mock_fetch_organism, _mock_fetch_definition, mock_consense
+    ):
+        dom_name = "all-demo"
+        models = {"JTT+G": ["0.1", "0"]}
+
+        _write_file(
+            DataPath(f"{dom_name}.fas"),
+            "Organism Alpha: Bacteria ACC1 1/1 1/1\nOrganism Beta: Archaea ACC2 1/1 1/1\n",
+        )
+        _write_file(
+            AlignsPath(f"{dom_name}.best.nex"),
+            "#NEXUS\nbegin data;\ndimensions ntax=2 nchar=4;\nformat datatype=protein interleave=no gap=-;\n"
+            "matrix\nOrgA AAAA\nOrgB AAAA\n;\nend;\n",
+        )
+        _write_file(
+            ProtPath(f"{dom_name}.pro"),
+            "Header\nBest model according to BIC\nskip1\nskip2\nskip3\nskip4\nJTT+G 100 10 0.9 -1000\nWAG 250 20 0.1 -1200\n",
+        )
+
+        prefix = f"{dom_name}-JTT-ori"
+        _write_file(MLPath(f"{prefix}_phyml_boot_trees.txt"), "tree1\n")
+
+        _write_file(
+            BayesPath(f"{dom_name}-bayes.nxs.con"),
+            "translate\n1 OrgA,\n2 OrgB,\n;\n"
+            "tree con_50 = [&R] (1[&prob=1.0],2[&prob=1.0]);\n",
+        )
+        _write_file(
+            BayesPath(f"{dom_name}-bayes.nxs.con.tre"),
+            "translate\n1 WrongA,\n2 WrongB,\n;\n"
+            "tree con_50 = [&R] (1[&prob=1.0],2[&prob=1.0]);\n",
+        )
+
+        Report.generate_report("demo", "QUERY123", models, "all")
+
+        report_path = str(ReportsPath(f"Report-{dom_name}.txt"))
+        trees_path = str(ReportsPath(f"{dom_name}-trees.tre"))
+
+        self.assertTrue(os.path.exists(report_path))
+        self.assertTrue(os.path.exists(trees_path))
+
+        with open(report_path) as report_file:
+            report_text = report_file.read()
+
+        self.assertIn("Reciprocal Best BLAST Results", report_text)
+        self.assertIn("Query organism", report_text)
+        self.assertIn("Model          deltaBIC*", report_text)
+        self.assertIn("JTT+G 100", report_text)
+        self.assertIn("Tree found by PhyML using the JTT model", report_text)
+        self.assertIn("OrgA[&prob=1.0]", report_text)
+        self.assertNotIn("WrongA[&prob=1.0]", report_text)
+
+        mock_consense.assert_called_once_with(str(MLPath(f"{prefix}_phyml_boot_trees.txt")))
+
+    @patch("Report.consense", return_value="(MLTREE);")
+    @patch("Report.FetchUtil.fetch_definition", side_effect=lambda acc: f"definition-for-{acc}")
+    @patch("Report.FetchUtil.fetch_organism", return_value=["Query organism", "Bacteria"])
+    def test_generate_report_falls_back_to_con_tre_when_con_missing(
+        self, _mock_fetch_organism, _mock_fetch_definition, _mock_consense
+    ):
+        dom_name = "bac-demo2"
+        models = {"WAG": ["0", "0"]}
+
+        _write_file(DataPath(f"{dom_name}.fas"), "Organism Gamma: Bacteria ACC9 1/1 1/1\n")
+        _write_file(
+            AlignsPath(f"{dom_name}.best.nex"),
+            "#NEXUS\nbegin data;\ndimensions ntax=1 nchar=4;\nformat datatype=protein interleave=no gap=-;\n"
+            "matrix\nOrgC AAAA\n;\nend;\n",
+        )
+        _write_file(
+            ProtPath(f"{dom_name}.pro"),
+            "Best model according to BIC\nskip1\nskip2\nskip3\nskip4\nWAG 100 10 0.9 -1000\nWAG2 250 20 0.1 -1200\n",
+        )
+
+        _write_file(
+            BayesPath(f"{dom_name}-bayes.nxs.con.tre"),
+            "translate\n1 OrgC,\n;\n"
+            "tree con_50 = [&R] (1[&prob=1.0]);\n",
+        )
+
+        Report.generate_report("demo2", "QUERY999", models, "bac")
+
+        report_path = str(ReportsPath(f"Report-{dom_name}.txt"))
+        self.assertTrue(os.path.exists(report_path))
+
+        with open(report_path) as report_file:
+            report_text = report_file.read()
+
+        self.assertIn("Tree found by MrBayes using the best model", report_text)
+        self.assertIn("OrgC[&prob=1.0]", report_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_RiskFixes.py
+++ b/test/test_RiskFixes.py
@@ -1,0 +1,65 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import Report
+from Utils import FetchUtil, SeqUtil
+
+
+class TestRiskFixes(unittest.TestCase):
+    @patch("Report.subprocess.run")
+    def test_consense_uses_subprocess_without_shell(self, mock_run):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            input_path = os.path.join(temp_dir, "input.txt")
+            with open(input_path, "w") as in_file:
+                in_file.write("dummy")
+
+            expected_tree_path = os.path.splitext(input_path)[0] + ".tre"
+            with open(expected_tree_path, "w") as tree_file:
+                tree_file.write("(A,B);")
+
+            result = Report.consense(input_path)
+            self.assertEqual(result, "(A,B);")
+            mock_run.assert_called_once()
+            _, kwargs = mock_run.call_args
+            self.assertEqual(kwargs["check"], True)
+            self.assertEqual(kwargs["text"], True)
+            self.assertIn(input_path, kwargs["input"])
+
+    @patch("Utils.SeqUtil.clustal_align")
+    def test_remove_gaps_nexus_does_not_mutate_dict_during_iteration(self, mock_clustal_align):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            in_path = os.path.join(temp_dir, "sample.nex")
+            out_path = os.path.join(temp_dir, "out.nex")
+            with open(in_path, "w") as handle:
+                handle.write(
+                    "#NEXUS\n"
+                    "begin data;\n"
+                    "dimensions ntax=3 nchar=4;\n"
+                    "format datatype=protein interleave=no gap=-;\n"
+                    "matrix\n"
+                    "A A--A\n"
+                    "B A--A\n"
+                    "C AAAA\n"
+                    ";\n"
+                    "end;\n"
+                )
+
+            SeqUtil.splice_align(in_path, out_path)
+            mock_clustal_align.assert_called_once()
+
+    @patch("Utils.FetchUtil.fetch_protein")
+    def test_fetch_organism_handles_definition_tokens_without_closing_bracket(self, mock_fetch_protein):
+        mock_fetch_protein.return_value = [
+            "DEFINITION\n",
+            "some protein [Organism only\n",
+            "ACCESSION\n",
+        ]
+
+        result = FetchUtil.fetch_organism("ACC")
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## TL;DR
Patch three remaining high-risk code paths and add dedicated `Report.py` test coverage.

## What changed
- `Report.consense`: replaced shell execution with `subprocess.run(..., input=..., text=True, check=True)`.
- `Utils.SeqUtil.splice_align`: avoid mutating dictionary while iterating (`list(pos.keys())`).
- `Utils.FetchUtil.fetch_organism`: add index/bounds guards for DEFINITION parsing.
- Added `test/test_RiskFixes.py` for regression checks on the above risks.
- Added `test/test_Report.py` for `generate_report()` behavior:
  - prefers `.con` over `.con.tre`
  - falls back to `.con.tre` when `.con` is missing
  - verifies report/tree output content and file generation

## Testing
- `./venv1/bin/python -m pytest -q test/test_RiskFixes.py` -> 3 passed
- `./venv1/bin/python -m pytest -q test/test_Report.py` -> 2 passed
- `./venv1/bin/python -m pytest -q` -> 23 passed

🌸 Generated with [AdaL](https://github.com/adal-cli/)